### PR TITLE
Load custom CA file for "default", just like "register" and "publish".

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -59,7 +59,7 @@ function loadCAs(caConfig) {
             return readCertFile(s);
         });
     }
-    ['register', 'publish'].forEach(function(p) {
+    ['register', 'publish', 'default'].forEach(function(p) {
         if (caConfig[p]) {
             caConfig[p] = readCertFile(caConfig[p]);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -120,7 +120,7 @@ describe('NPM Config on package.json', function () {
             var config = require('../lib/Config')
                 .read(path.resolve('test/assets/custom-ca'));
 
-            ['register', 'publish'].forEach(function (p) {
+            ['register', 'publish', 'default'].forEach(function (p) {
                 assertCAContents(config.ca[p], 'config.ca.' + p);
             });
 
@@ -136,7 +136,7 @@ describe('NPM Config on package.json', function () {
             var config = require('../lib/Config')
                 .read(path.resolve('test/assets/custom-ca-embed'));
 
-            ['register', 'publish'].forEach(function (p) {
+            ['register', 'publish', 'default'].forEach(function (p) {
                 assertCAContents(config.ca[p], 'config.ca.' + p);
             });
 


### PR DESCRIPTION
I just spent a bunch of time looking at this while trying to fix JFrogDev/bower-art-resolver#11. AFAICT only the ca.search property is supposed to support being specified as an array. The [registry client](https://github.com/bower/registry-client) uses it:

> **registry.search: an array of registry search endpoints (defaults to the Bower server)**
> registry.register: the endpoint to use when registering packages (defaults to the Bower server)
> registry.publish: the endpoint to use when publishing packages (defaults to the Bower server)
> **ca.search: an array of CA certificates for each registry.search (defaults to null).**
> ca.register: the CA certificate for registry.register
> ca.publish: the CA certificate for registry.publish

Other parts of the code, such as the [GitHubResolver](https://github.com/bower/bower/blob/ce15df27ca728349799b3c6a2db1a5f1e9b4e9e8/lib/core/resolvers/GitHubResolver.js#L75) assume that default (and probably register and publish too) is just an array of strings. The processed ca.search configuration option is assumed to be an array of an array of strings.
Your original implementation would've allowed the user to specify multiple sets of CA certs for default, register, and publish. If they did so then it would (probably quietly) break things in other parts of bower.
